### PR TITLE
docs: add deployment strategy and decisions

### DIFF
--- a/.specify/memory/deployment-workflow.md
+++ b/.specify/memory/deployment-workflow.md
@@ -1,0 +1,181 @@
+# Deployment Strategy & Decisions
+
+**Purpose**: Document deployment strategy, design decisions, and the rationale behind our release workflow.
+
+**Status**: Implemented (v0.9.7)
+**Implementation**: See `.github/workflows/ci.yml` and `.github/workflows/release.yml` for details
+**Repository**: https://github.com/orb-zone/dotted-json
+
+---
+
+## Philosophy
+
+**Single Source of Truth**: The `.github/workflows/*.yml` files define what actually runs.
+
+**This document explains**:
+- Why we chose certain approaches
+- Strategic decisions for AI agents to understand
+- High-level workflow concepts (details live in YAML)
+
+```
+Feature Branch → PR → main → Tag → Automated Release
+```
+
+---
+
+## Key Decisions
+
+### 1. JSR-First Publishing Strategy
+
+**Decision**: Publish to JSR.io, defer NPM until v1.0
+
+**Rationale**:
+- JSR is designed for TypeScript-first packages
+- We publish source TypeScript (not transpiled dist)
+- OIDC authentication = zero secrets to manage
+- Better alignment with modern JS ecosystem
+
+**When NPM?**: Re-enable after v1.0 when API is stable
+
+### 2. OIDC Authentication for JSR
+
+**Decision**: Use GitHub OIDC instead of manual tokens
+
+**Rationale**:
+- No secrets to rotate or leak
+- Automatic when package linked to GitHub repo
+- Simpler workflow maintenance
+- Industry best practice (2024+)
+
+**Requirement**: Package must be linked on JSR.io to GitHub repository
+
+### 3. PR-Only Workflow with Branch Protection
+
+**Decision**: Block direct pushes to `main` via Lefthook pre-push hooks
+
+**Rationale**:
+- Forces code review for all changes
+- CI runs on every PR before merge
+- Prevents accidental breaking changes
+- Maintains audit trail
+
+**Enforcement**: `lefthook.yml` pre-push hook + GitHub branch protection (recommended)
+
+### 4. Tag-Based Releases
+
+**Decision**: Manual tagging triggers automated release
+
+**Rationale**:
+- Gives developer control over release timing
+- Tag annotations provide structured release notes
+- Separates "code ready" (merge to main) from "release ready" (tag)
+- Follows Git best practices
+
+**Workflow**: See `.github/workflows/release.yml` for implementation details
+
+### 5. Bun Runtime
+
+**Decision**: Use Bun for CI/CD (not Node.js/npm)
+
+**Rationale**:
+- Faster dependency installation
+- Native TypeScript support
+- Modern tooling alignment
+- Single runtime for dev and CI
+
+**Version**: Bun v2 (setup-bun@v2)
+
+---
+
+## Release Process (Quick Reference)
+
+**For agents**: Follow standard Git workflow. Key commands:
+
+```bash
+# 1. Feature work on branch (NOT main)
+git checkout -b feat/feature-name
+
+# 2. Create PR (pre-push hook blocks direct push to main)
+gh pr create --base main --head feat/feature-name
+
+# 3. After merge, tag from main to release
+git checkout main && git pull
+git tag -a v0.9.8 -m "Release notes"
+git push origin v0.9.8
+
+# Tag push triggers .github/workflows/release.yml automatically
+```
+
+**Implementation details**: See workflow YAML files, not this doc.
+
+---
+
+## JSR Publishing Notes
+
+**One-time setup**:
+- Link package `@orb-zone/dotted-json` on JSR.io to GitHub repo
+- OIDC authentication is automatic (no secrets needed)
+
+**Configuration**: `jsr.json` defines package metadata and publish settings
+
+**Key insight**: JSR publishes TypeScript source, not transpiled JavaScript. This aligns with our TypeScript-first philosophy.
+
+---
+
+## For AI Agents: Standard Operations
+
+### Creating a Release
+
+1. **Verify main is clean**: All PRs merged, CI passing
+2. **Bump versions**: Update `jsr.json`, `package.json`, `CHANGELOG.md` (via PR)
+3. **Tag release**: `git tag -a v0.9.8 -m "Release notes"`
+4. **Push tag**: `git push origin v0.9.8`
+5. **Workflow handles rest**: Tests, build, GitHub release, JSR publish
+
+### Handling CI Failures
+
+- Lint errors: `bun run lint --fix`
+- Type errors: `bun run typecheck`
+- Test failures: `bun test`
+- Build issues: `bun run build`
+
+**Always run locally before pushing** to catch issues early.
+
+### Emergency Procedures
+
+**Hotfix**: Branch from main, PR, merge, tag immediately
+**Rollback**: Revert PR on main, tag new patch version
+**Failed release**: Re-run workflow from GitHub Actions UI
+
+---
+
+## Strategic Roadmap
+
+### v1.0 Milestone
+- [ ] Re-enable NPM publishing alongside JSR
+- [ ] Automated changelog generation from conventional commits
+- [ ] Bundle size monitoring in CI
+
+### Future Considerations
+- Multi-runtime testing (Node.js, Deno, Bun)
+- Canary releases for early adopters
+- Performance regression tracking
+
+---
+
+## Related Files
+
+**Implementation** (source of truth):
+- `.github/workflows/ci.yml` - CI workflow
+- `.github/workflows/release.yml` - Release workflow
+- `lefthook.yml` - Git hooks
+- `jsr.json` - JSR package config
+
+**Context**:
+- [Maintenance Log](./maintenance-log.md) - Quality checklists
+- [Constitution](./constitution.md) - Project principles
+
+---
+
+**Last Updated**: 2025-10-12
+**Philosophy**: YAML configs are truth, this doc explains "why"


### PR DESCRIPTION
Adds  documenting the **why** behind our deployment approach.

## Key Decisions Documented

1. **JSR-first publishing** - TypeScript source, OIDC auth, modern ecosystem
2. **PR-only workflow** - Branch protection via Lefthook
3. **Tag-based releases** - Developer control over release timing
4. **Bun runtime** - Fast, TypeScript-native CI/CD

## Philosophy

-  files are source of truth (implementation)
-  explains strategic decisions (context for AI agents)
- No duplication of YAML config details

Closes #4 (if we had one for this)