### PR TITLE
fix: checkout main branch in JSR publish workflow

### DIFF
--- a/.changeset/fix-jsr-publish-ref.md
+++ b/.changeset/fix-jsr-publish-ref.md
@@ -1,0 +1,8 @@
+---
+"@orb-zone/dotted-json": patch
+---
+
+**JSR Publish Fix**
+
+- **Fixed**: Publish workflow now explicitly checks out `main` branch after Version Packages PR merge
+- **Resolved**: Ensures correct version is published to JSR (was publishing old version from PR branch)

--- a/.github/workflows/publish-jsr.yml
+++ b/.github/workflows/publish-jsr.yml
@@ -19,6 +19,8 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
+        with:
+          ref: main  # Explicitly checkout main after PR merge
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2


### PR DESCRIPTION
## Problem

The JSR publish workflow was checking out the PR branch instead of the merged `main` branch, causing it to publish the old version (0.10.1) instead of the bumped version (0.12.1).

## Root Cause

When triggered by `pull_request.closed`, `actions/checkout@v4` defaults to checking out the PR head ref, not the base branch. This meant the workflow was publishing the code **before** the version bump was merged.

## Solution

Explicitly set `ref: main` in the checkout step to ensure we're publishing the correct version from the main branch after the PR merge.

## Testing

- [x] Changeset added for v0.12.2 patch
- [ ] Will test full workflow after merge

## Expected Flow After Fix

1. Merge Version Packages PR → triggers publish workflow
2. Workflow checks out `main` branch (✅ now explicit)
3. Builds with correct version from package.json
4. Publishes to JSR with bumped version

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>